### PR TITLE
feat: use concept of changes = effects + view state

### DIFF
--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
@@ -72,7 +72,7 @@ class MSMovieActivity : MSActivity() {
         val restoreFromHistoryEvents: Observable<RestoreFromHistoryEvent> = historyItemClick
             .map { RestoreFromHistoryEvent(it) }
 
-        disposable = viewModel.render(
+        disposable = viewModel.viewChanges(
             screenLoadEvents,
             searchMovieEvents,
             addToHistoryEvents,

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
@@ -7,6 +7,7 @@ import android.support.v4.widget.CircularProgressDrawable
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutCompat.HORIZONTAL
 import android.support.v7.widget.LinearLayoutManager
+import android.widget.Toast
 import co.kaush.msusf.MSActivity
 import co.kaush.msusf.R
 import co.kaush.msusf.movies.MSMovieEvent.AddToHistoryEvent
@@ -82,24 +83,35 @@ class MSMovieActivity : MSActivity() {
             .subscribe(
                 { change ->
 
-                    change.vs.searchBoxText?.let {
-                        ms_mainScreen_searchText.setText(it)
-                    }
-                    ms_mainScreen_title.text = change.vs.searchedMovieTitle
-                    ms_mainScreen_rating.text = change.vs.searchedMovieRating
+                    change.vs.let { vs ->
+                        vs.searchBoxText?.let {
+                            ms_mainScreen_searchText.setText(it)
+                        }
+                        ms_mainScreen_title.text = vs.searchedMovieTitle
+                        ms_mainScreen_rating.text = vs.searchedMovieRating
 
-                    change.vs.searchedMoviePoster
-                        .takeIf { it.isNotBlank() }
-                        ?.let {
-                            Glide.with(ctx)
-                                .load(change.vs.searchedMoviePoster)
-                                .placeholder(spinner)
-                                .into(ms_mainScreen_poster)
-                        } ?: run {
-                        ms_mainScreen_poster.setImageResource(0)
+                        vs.searchedMoviePoster
+                            .takeIf { it.isNotBlank() }
+                            ?.let {
+                                Glide.with(ctx)
+                                    .load(vs.searchedMoviePoster)
+                                    .placeholder(spinner)
+                                    .into(ms_mainScreen_poster)
+                            } ?: run {
+                            ms_mainScreen_poster.setImageResource(0)
+                        }
+
+                        listAdapter.submitList(vs.adapterList)
                     }
 
-                    listAdapter.submitList(change.vs.adapterList)
+                    change.effects.forEach {
+                        when (it) {
+                            is MSMovieViewEffect.AddedToHistoryToastEffect -> {
+                                Toast.makeText(this, "added to history", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+
                 },
                 { Timber.w(it, "something went terribly wrong") }
             )

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
@@ -80,25 +80,26 @@ class MSMovieActivity : MSActivity() {
         )
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
-                { vs ->
-                    vs.searchBoxText?.let {
+                { change ->
+
+                    change.vs.searchBoxText?.let {
                         ms_mainScreen_searchText.setText(it)
                     }
-                    ms_mainScreen_title.text = vs.searchedMovieTitle
-                    ms_mainScreen_rating.text = vs.searchedMovieRating
+                    ms_mainScreen_title.text = change.vs.searchedMovieTitle
+                    ms_mainScreen_rating.text = change.vs.searchedMovieRating
 
-                    vs.searchedMoviePoster
+                    change.vs.searchedMoviePoster
                         .takeIf { it.isNotBlank() }
                         ?.let {
                             Glide.with(ctx)
-                                .load(vs.searchedMoviePoster)
+                                .load(change.vs.searchedMoviePoster)
                                 .placeholder(spinner)
                                 .into(ms_mainScreen_poster)
                         } ?: run {
                         ms_mainScreen_poster.setImageResource(0)
                     }
 
-                    listAdapter.submitList(vs.adapterList)
+                    listAdapter.submitList(change.vs.adapterList)
                 },
                 { Timber.w(it, "something went terribly wrong") }
             )

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
@@ -73,7 +73,7 @@ class MSMovieActivity : MSActivity() {
         val restoreFromHistoryEvents: Observable<RestoreFromHistoryEvent> = historyItemClick
             .map { RestoreFromHistoryEvent(it) }
 
-        disposable = viewModel.viewChanges(
+        disposable = viewModel.processInputs(
             screenLoadEvents,
             searchMovieEvents,
             addToHistoryEvents,

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieViewState.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieViewState.kt
@@ -9,6 +9,10 @@ data class MSMovieViewState(
     val adapterList: List<MSMovie> = emptyList()
 )
 
+sealed class MSMovieViewEffect
+
+data class MSMovieViewChange(val vs: MSMovieViewState, var effects: List<MSMovieViewEffect> = emptyList())
+
 sealed class MSMovieEvent {
     object ScreenLoadEvent : MSMovieEvent()
     data class SearchMovieEvent(val searchedMovieTitle: String = "") : MSMovieEvent()

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieViewState.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieViewState.kt
@@ -9,7 +9,9 @@ data class MSMovieViewState(
     val adapterList: List<MSMovie> = emptyList()
 )
 
-sealed class MSMovieViewEffect
+sealed class MSMovieViewEffect {
+    object AddedToHistoryToastEffect: MSMovieViewEffect()
+}
 
 data class MSMovieViewChange(val vs: MSMovieViewState, var effects: List<MSMovieViewEffect> = emptyList())
 

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
@@ -29,7 +29,7 @@ class MSMainVm(
 
     private var viewState: MSMovieViewState = MSMovieViewState()
 
-    fun render(vararg es: Observable<out MSMovieEvent>): Observable<MSMovieViewState> {
+    fun viewChanges(vararg es: Observable<out MSMovieEvent>): Observable<MSMovieViewState> {
 
         // gather events
         val events: Observable<out MSMovieEvent> =

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
@@ -30,7 +30,7 @@ class MSMainVm(
 
     private var viewState: MSMovieViewState = MSMovieViewState()
 
-    fun viewChanges(vararg es: Observable<out MSMovieEvent>): Observable<MSMovieViewChange> {
+    fun processInputs(vararg es: Observable<out MSMovieEvent>): Observable<MSMovieViewChange> {
 
         // gather events
         val events: Observable<out MSMovieEvent> =

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
@@ -96,7 +96,7 @@ class MSMainVm(
                                         change.vs.copy(adapterList = adapterList),
                                         listOf(AddedToHistoryToastEffect)
                                     )
-                                } ?: MSMovieViewChange(change.vs.copy())
+                                } ?: MSMovieViewChange(change.vs.copy(), listOf(AddedToHistoryToastEffect))
                         }
                     }
                 }
@@ -124,7 +124,6 @@ class MSMainVm(
                 }
             }
         }
-        .distinctUntilChanged()
         .doOnNext { viewState = it.vs }
     }
 

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieVm.kt
@@ -11,6 +11,7 @@ import co.kaush.msusf.movies.MSMovieEvent.SearchMovieEvent
 import co.kaush.msusf.movies.MSMovieResult.ScreenLoadResult
 import co.kaush.msusf.movies.MSMovieResult.SearchHistoryResult
 import co.kaush.msusf.movies.MSMovieResult.SearchMovieResult
+import co.kaush.msusf.movies.MSMovieViewEffect.*
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import io.reactivex.schedulers.Schedulers
@@ -92,7 +93,8 @@ class MSMainVm(
                                         mutableListOf(*change.vs.adapterList.toTypedArray())
                                     adapterList.add(it)
                                     MSMovieViewChange(
-                                        change.vs.copy(adapterList = adapterList)
+                                        change.vs.copy(adapterList = adapterList),
+                                        listOf(AddedToHistoryToastEffect)
                                     )
                                 } ?: MSMovieViewChange(change.vs.copy())
                         }

--- a/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
+++ b/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
@@ -37,7 +37,7 @@ class MSMainVmTest {
         eventTester.onNext(ScreenLoadEvent)
 
         viewModelTester.assertValueAt(1) {
-            assertThat(it.searchBoxText).isEqualTo("")
+            assertThat(it.vs.searchBoxText).isEqualTo("")
             true
         }
     }
@@ -56,15 +56,15 @@ class MSMainVmTest {
         assertThat(viewModelTester.valueCount()).isEqualTo(3)
 
         viewModelTester.assertValueAt(1) {
-            assertThat(it.searchedMovieTitle).isEqualTo("Searching Movie...")
+            assertThat(it.vs.searchedMovieTitle).isEqualTo("Searching Movie...")
             true
         }
 
         viewModelTester.assertValueAt(2) {
-            assertThat(it.searchedMovieTitle).isEqualTo("Blade Runner 2049")
-            assertThat(it.searchedMoviePoster)
+            assertThat(it.vs.searchedMovieTitle).isEqualTo("Blade Runner 2049")
+            assertThat(it.vs.searchedMoviePoster)
                 .isEqualTo("https://m.media-amazon.com/images/M/MV5BNzA1Njg4NzYxOV5BMl5BanBnXkFtZTgwODk5NjU3MzI@._V1_SX300.jpg")
-            assertThat(it.searchedMovieRating).isEqualTo("\n8.1/10 (IMDB)\n87% (RT)")
+            assertThat(it.vs.searchedMovieRating).isEqualTo("\n8.1/10 (IMDB)\n87% (RT)")
 
             true
         }
@@ -90,9 +90,9 @@ class MSMainVmTest {
         assertThat(viewModelTester.valueCount()).isEqualTo(4)
 
         viewModelTester.assertValueAt(3) {
-            assertThat(it.searchBoxText).isEqualTo(null) // prevents search box from reset
-            assertThat(it.adapterList).hasSize(1)
-            assertThat(it.adapterList[0]).isEqualTo(bladeRunner2049)
+            assertThat(it.vs.searchBoxText).isEqualTo(null) // prevents search box from reset
+            assertThat(it.vs.adapterList).hasSize(1)
+            assertThat(it.vs.adapterList[0]).isEqualTo(bladeRunner2049)
             true
         }
     }
@@ -114,23 +114,23 @@ class MSMainVmTest {
 
         // check that the result is showing Blade
         viewModelTester.assertValueAt(viewModelTester.valueCount() - 1) {
-            assertThat(it.searchedMovieTitle).isEqualTo("Blade")
+            assertThat(it.vs.searchedMovieTitle).isEqualTo("Blade")
             true
         }
 
         // click blade runner 2049 from history
         eventTester.onNext(RestoreFromHistoryEvent(bladeRunner2049))
         viewModelTester.assertValueAt(viewModelTester.valueCount() - 1) {
-            assertThat(it.searchedMovieTitle).isEqualTo("Blade Runner 2049")
-            assertThat(it.searchedMovieRating).isEqualTo(bladeRunner2049.ratingSummary)
+            assertThat(it.vs.searchedMovieTitle).isEqualTo("Blade Runner 2049")
+            assertThat(it.vs.searchedMovieRating).isEqualTo(bladeRunner2049.ratingSummary)
             true
         }
 
         // click blade again
         eventTester.onNext(RestoreFromHistoryEvent(blade))
         viewModelTester.assertValueAt(viewModelTester.valueCount() - 1) {
-            assertThat(it.searchedMovieTitle).isEqualTo("Blade")
-            assertThat(it.searchedMovieRating).isEqualTo(blade.ratingSummary)
+            assertThat(it.vs.searchedMovieTitle).isEqualTo("Blade")
+            assertThat(it.vs.searchedMovieRating).isEqualTo(blade.ratingSummary)
             true
         }
     }

--- a/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
+++ b/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
@@ -5,6 +5,7 @@ import co.kaush.msusf.movies.MSMovieEvent.AddToHistoryEvent
 import co.kaush.msusf.movies.MSMovieEvent.RestoreFromHistoryEvent
 import co.kaush.msusf.movies.MSMovieEvent.ScreenLoadEvent
 import co.kaush.msusf.movies.MSMovieEvent.SearchMovieEvent
+import co.kaush.msusf.movies.MSMovieViewEffect.*
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
@@ -93,6 +94,8 @@ class MSMainVmTest {
             assertThat(it.vs.searchBoxText).isEqualTo(null) // prevents search box from reset
             assertThat(it.vs.adapterList).hasSize(1)
             assertThat(it.vs.adapterList[0]).isEqualTo(bladeRunner2049)
+            assertThat(it.effects.size).isEqualTo(1)
+            assertThat(it.effects[0]).isEqualTo(AddedToHistoryToastEffect)
             true
         }
     }

--- a/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
+++ b/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
@@ -22,7 +22,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.render(eventTester).test()
+        val viewModelTester = viewModel.viewChanges(eventTester).test()
 
         viewModelTester.assertValueCount(1)
     }
@@ -32,7 +32,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.render(eventTester).test()
+        val viewModelTester = viewModel.viewChanges(eventTester).test()
 
         eventTester.onNext(ScreenLoadEvent)
 
@@ -47,7 +47,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.render(eventTester).test()
+        val viewModelTester = viewModel.viewChanges(eventTester).test()
 
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))
 
@@ -75,7 +75,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.render(eventTester).test()
+        val viewModelTester = viewModel.viewChanges(eventTester).test()
 
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))
 
@@ -102,7 +102,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.render(eventTester).test()
+        val viewModelTester = viewModel.viewChanges(eventTester).test()
 
         // populate history
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))

--- a/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
+++ b/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
@@ -22,7 +22,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.viewChanges(eventTester).test()
+        val viewModelTester = viewModel.processInputs(eventTester).test()
 
         viewModelTester.assertValueCount(1)
     }
@@ -32,7 +32,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.viewChanges(eventTester).test()
+        val viewModelTester = viewModel.processInputs(eventTester).test()
 
         eventTester.onNext(ScreenLoadEvent)
 
@@ -47,7 +47,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.viewChanges(eventTester).test()
+        val viewModelTester = viewModel.processInputs(eventTester).test()
 
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))
 
@@ -75,7 +75,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.viewChanges(eventTester).test()
+        val viewModelTester = viewModel.processInputs(eventTester).test()
 
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))
 
@@ -102,7 +102,7 @@ class MSMainVmTest {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
         val eventTester = PublishSubject.create<MSMovieEvent>()
-        val viewModelTester = viewModel.viewChanges(eventTester).test()
+        val viewModelTester = viewModel.processInputs(eventTester).test()
 
         // populate history
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))

--- a/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
+++ b/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
@@ -51,7 +51,6 @@ class MSMainVmTest {
         val viewModelTester = viewModel.processInputs(eventTester).test()
 
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))
-
         viewModelTester.awaitTerminalEvent(20L, TimeUnit.MILLISECONDS)
 
         assertThat(viewModelTester.valueCount()).isEqualTo(3)
@@ -79,14 +78,11 @@ class MSMainVmTest {
         val viewModelTester = viewModel.processInputs(eventTester).test()
 
         eventTester.onNext(SearchMovieEvent("blade runner 2049"))
-
         viewModelTester.awaitTerminalEvent(20L, TimeUnit.MILLISECONDS)
 
         assertThat(viewModelTester.valueCount()).isEqualTo(3)
 
         eventTester.onNext(AddToHistoryEvent)
-
-        viewModelTester.awaitTerminalEvent(20L, TimeUnit.MILLISECONDS)
 
         assertThat(viewModelTester.valueCount()).isEqualTo(4)
 
@@ -94,6 +90,25 @@ class MSMainVmTest {
             assertThat(it.vs.searchBoxText).isEqualTo(null) // prevents search box from reset
             assertThat(it.vs.adapterList).hasSize(1)
             assertThat(it.vs.adapterList[0]).isEqualTo(bladeRunner2049)
+            assertThat(it.effects.size).isEqualTo(1)
+            assertThat(it.effects[0]).isEqualTo(AddedToHistoryToastEffect)
+            true
+        }
+    }
+
+    @Test
+    fun onClickingMovieSearchResultTwice_shouldShowToastEachTime() {
+        viewModel = MSMainVm(mockApp, mockMovieRepo)
+
+        val eventTester = PublishSubject.create<MSMovieEvent>()
+        val viewModelTester = viewModel.processInputs(eventTester).test()
+
+        eventTester.onNext(SearchMovieEvent("blade runner 2049"))
+        viewModelTester.awaitTerminalEvent(20L, TimeUnit.MILLISECONDS)
+        eventTester.onNext(AddToHistoryEvent)
+        eventTester.onNext(AddToHistoryEvent)
+
+        viewModelTester.assertValueAt(4) {
             assertThat(it.effects.size).isEqualTo(1)
             assertThat(it.effects[0]).isEqualTo(AddedToHistoryToastEffect)
             true


### PR DESCRIPTION
the idea is to not encode one time like effects within the view state. For example, if we want a toast shown, if we encode it into the view state, then every time that screen loads, it would show the toast again which is not what we want. We have a couple of options:

1. add a timer like functionality that resets the view state
2. add a concept of "view effect" in parallel to view state.

I imagine view effects could be used to re-trigger events again too. 